### PR TITLE
Add --grace period for short password free unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,14 @@ Swaylock will drop root permissions shortly after startup.
 ## New Features
 
 * `--command <cmd>` to run a program which draws the background using wlr_layer_shell
+* `--grace <seconds>` to set a password grace period, so that the password
+  isn't required to unlock until some number of seconds have passed.
+    * Used together with `--indicator`, the indicator is always shown,
+      even in the grace period.
+    * Used together with `--indicator-idle-visible`, the indicator is only
+      visible after the grace period.
+    * By default, either a key press or a mouse event will unlock
+      during the grace period. Use `--grace-no-mouse` to only unlock
+      as a response to a key event.
+* `--grace-no-mouse*` With *--grace*, only unlock as a response to a
+    key event, not in response to a mouse event.

--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ On systems without PAM, you need to suid the swaylock-plugin binary:
     sudo chmod a+s /usr/local/bin/swaylock-plugin
 
 Swaylock will drop root permissions shortly after startup.
+
+## New Features
+
+* `--command <cmd>` to run a program which draws the background using wlr_layer_shell

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -16,6 +16,7 @@ enum auth_state {
 	AUTH_STATE_IDLE, // nothing happening
 	AUTH_STATE_VALIDATING, // currently validating password
 	AUTH_STATE_INVALID, // displaying message: password was wrong
+	AUTH_STATE_GRACE, // state where the screen can be unlocked without password
 };
 
 // Indicator state: status of password buffer / typing letters
@@ -72,6 +73,8 @@ struct swaylock_args {
 	bool daemonize;
 	int ready_fd;
 	bool indicator_idle_visible;
+	uint32_t password_grace_period;
+	bool password_grace_no_mouse;
 	char *plugin_command;
 };
 
@@ -328,6 +331,7 @@ struct swaylock_image {
 
 void swaylock_handle_key(struct swaylock_state *state,
 		xkb_keysym_t keysym, uint32_t codepoint);
+void swaylock_handle_mouse(struct swaylock_state *state);
 void render_frame_background(struct swaylock_surface *surface);
 void render_frame(struct swaylock_surface *surface);
 void damage_surface(struct swaylock_surface *surface);

--- a/main.c
+++ b/main.c
@@ -968,7 +968,7 @@ static int parse_options(int argc, char **argv, struct swaylock_state *state,
 			"Sets the color of the text when verifying.\n"
 		"  --text-wrong-color <color>       "
 			"Sets the color of the text when invalid.\n"
-		"  --command <cmd>       "
+		"  --command <cmd>                  "
 			"Indicates which program to run to draw background.\n"
 		"\n"
 		"All <color> options are of the form <rrggbb[aa]>.\n";

--- a/password.c
+++ b/password.c
@@ -131,8 +131,18 @@ static void update_highlight(struct swaylock_state *state) {
 		(state->highlight_start + (rand() % 1024) + 512) % 2048;
 }
 
+void swaylock_handle_mouse(struct swaylock_state *state) {
+	if (state->auth_state == AUTH_STATE_GRACE && !state->args.password_grace_no_mouse) {
+		state->run_display = false;
+	}
+}
+
 void swaylock_handle_key(struct swaylock_state *state,
 		xkb_keysym_t keysym, uint32_t codepoint) {
+	if (state->auth_state == AUTH_STATE_GRACE) {
+		state->run_display = false;
+		return;
+	}
 
 	switch (keysym) {
 	case XKB_KEY_KP_Enter: /* fallthrough */

--- a/render.c
+++ b/render.c
@@ -64,7 +64,8 @@ void render_frame(struct swaylock_surface *surface) {
 	bool draw_indicator = state->args.show_indicator &&
 		(state->auth_state != AUTH_STATE_IDLE ||
 			state->input_state != INPUT_STATE_IDLE ||
-			state->args.indicator_idle_visible);
+			state->args.indicator_idle_visible) &&
+		 state->auth_state != AUTH_STATE_GRACE;
 
 	if (draw_indicator) {
 		if (state->input_state == INPUT_STATE_CLEAR) {

--- a/seat.c
+++ b/seat.c
@@ -142,17 +142,17 @@ static void wl_pointer_leave(void *data, struct wl_pointer *wl_pointer,
 
 static void wl_pointer_motion(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, wl_fixed_t surface_x, wl_fixed_t surface_y) {
-	// Who cares
+	swaylock_handle_mouse((struct swaylock_state *)data);
 }
 
 static void wl_pointer_button(void *data, struct wl_pointer *wl_pointer,
 		uint32_t serial, uint32_t time, uint32_t button, uint32_t state) {
-	// Who cares
+	swaylock_handle_mouse((struct swaylock_state *)data);
 }
 
 static void wl_pointer_axis(void *data, struct wl_pointer *wl_pointer,
 		uint32_t time, uint32_t axis, wl_fixed_t value) {
-	// Who cares
+	swaylock_handle_mouse((struct swaylock_state *)data);
 }
 
 static void wl_pointer_frame(void *data, struct wl_pointer *wl_pointer) {
@@ -199,7 +199,7 @@ static void seat_handle_capabilities(void *data, struct wl_seat *wl_seat,
 	}
 	if ((caps & WL_SEAT_CAPABILITY_POINTER)) {
 		seat->pointer = wl_seat_get_pointer(wl_seat);
-		wl_pointer_add_listener(seat->pointer, &pointer_listener, NULL);
+		wl_pointer_add_listener(seat->pointer, &pointer_listener, seat->state);
 	}
 	if ((caps & WL_SEAT_CAPABILITY_KEYBOARD)) {
 		seat->keyboard = wl_seat_get_keyboard(wl_seat);

--- a/swaylock.1.scd
+++ b/swaylock.1.scd
@@ -38,6 +38,17 @@ Locks your Wayland session.
 
 	Note: this is the default behavior of i3lock.
 
+*--grace* <seconds>
+	Only require a password after some grace period.
+
+	Note: Together with *--indicator*, the indicator is always shown.
+	Together with *--indicator-idle-visible*, the indicator is only shown
+	after the grace period.
+
+*--grace-no-mouse*
+	With *--grace*, only unlock as a response to a
+	key event, not in response to a mouse event.
+
 *-R, --ready-fd* <fd>
 	File descriptor to send readiness notifications to.
 


### PR DESCRIPTION
This is mostly from swaylock-effects. 

When the screen is just starting to lock it can still be unlocked
without a password by pressing a button or moving the mouse during the
time specified by --grace.
Unlocking with mouse can be switched off with the argument
--grace-no-mouse.

Signed-off-by: Pascal Jäger <pascal.jaeger@leimstift.de>