### PR TITLE
Fix GCC maybe-uninitialized sw_surface

### DIFF
--- a/main.c
+++ b/main.c
@@ -1660,7 +1660,7 @@ void wlr_layer_shell_get_layer_surface(struct wl_client *client,
 	struct forward_surface *surf = wl_resource_get_user_data(surface);
 	struct swaylock_state *state = wl_resource_get_user_data(resource);
 
-	struct swaylock_surface *sw_surface;
+	struct swaylock_surface *sw_surface = NULL;
 	if ((state->server.main_client && client == state->server.main_client->client) || output) {
 		if (!output) {
 			swaylock_log(LOG_ERROR, "Main client tried to create a layer surface without specifying an output");
@@ -1676,12 +1676,12 @@ void wlr_layer_shell_get_layer_surface(struct wl_client *client,
 				sw_surface = bg_client->unique_output;
 			}
 		}
-		if (!sw_surface) {
-			swaylock_log(LOG_ERROR, "Failed to find an output matching client");
-			return;
-		}
 	}
 
+        if (!sw_surface) {
+          swaylock_log(LOG_ERROR, "Failed to find an output matching client");
+          return;
+        }
 	// todo: replace the old surface instead; this will simplify implementation
 	// of plugin command restarting
 	if (sw_surface->plugin_surface) {


### PR DESCRIPTION
Building the project with GCC having Werr enabled, we end up with a maybe-unitialiwed error:

```
$ ninja -C build
ninja: Entering directory `build'
[1/2] Compiling C object swaylock-plugin.p/main.c.o FAILED: swaylock-plugin.p/main.c.o
(...)
../main.c:1682:12: erreur: « sw_surface » pourrait être utilisé sans être initialisé [-Werror=maybe-uninitialized]
 1682 |         if (sw_surface == NULL) {
      |            ^
../main.c:1663:34: note: « sw_surface » a été déclaré ici
 1663 |         struct swaylock_surface *sw_surface;
      |                                  ^~~~~~~~~~
```

Adding a sentinel NULL value to the surface and moving the check out of the if condition just to be sure wl_resource_get_user_data does not fail.

I think we're mostly pleasing GCC here, I don't think this was unsafe. But I'm not a C guru either.