### PR TITLE
Advertise wl_subcompositor and a minimal wl_seat to plugins

### DIFF
--- a/forward.c
+++ b/forward.c
@@ -1241,6 +1241,67 @@ void bind_viewporter(struct wl_client *client, void *data,
 	wl_resource_set_implementation(resource, &viewporter_impl, forward, NULL);
 }
 
+/* Minimal wl_subcompositor. Some toolkits (foot; smithay-client-toolkit, as
+ * used by alacritty) require wl_subcompositor to be present at startup even
+ * when the program renders its content as a single top-level surface. Plugin
+ * child surfaces are never given a lock-surface role, so their commits are
+ * already ignored by nested_surface_commit(); accepting subsurface creation
+ * therefore lets such programs start and draw their main surface, without
+ * compositing the (typically decorative/hidden) subsurface content. */
+static void nested_subsurface_set_position(struct wl_client *client,
+		struct wl_resource *resource, int32_t x, int32_t y) { }
+static void nested_subsurface_place_above(struct wl_client *client,
+		struct wl_resource *resource, struct wl_resource *sibling) { }
+static void nested_subsurface_place_below(struct wl_client *client,
+		struct wl_resource *resource, struct wl_resource *sibling) { }
+static void nested_subsurface_set_sync(struct wl_client *client,
+		struct wl_resource *resource) { }
+static void nested_subsurface_set_desync(struct wl_client *client,
+		struct wl_resource *resource) { }
+static void nested_subsurface_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+static const struct wl_subsurface_interface subsurface_impl = {
+	.destroy = nested_subsurface_destroy,
+	.set_position = nested_subsurface_set_position,
+	.place_above = nested_subsurface_place_above,
+	.place_below = nested_subsurface_place_below,
+	.set_sync = nested_subsurface_set_sync,
+	.set_desync = nested_subsurface_set_desync,
+};
+
+static void nested_subcompositor_destroy(struct wl_client *client,
+		struct wl_resource *resource) {
+	wl_resource_destroy(resource);
+}
+static void nested_subcompositor_get_subsurface(struct wl_client *client,
+		struct wl_resource *resource, uint32_t id, struct wl_resource *surface,
+		struct wl_resource *parent) {
+	struct wl_resource *subsurface = wl_resource_create(client,
+		&wl_subsurface_interface, wl_resource_get_version(resource), id);
+	if (subsurface == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	wl_resource_set_implementation(subsurface, &subsurface_impl, NULL, NULL);
+}
+static const struct wl_subcompositor_interface subcompositor_impl = {
+	.destroy = nested_subcompositor_destroy,
+	.get_subsurface = nested_subcompositor_get_subsurface,
+};
+
+void bind_wl_subcompositor(struct wl_client *client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wl_resource *resource =
+		wl_resource_create(client, &wl_subcompositor_interface, version, id);
+	if (resource == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	wl_resource_set_implementation(resource, &subcompositor_impl, NULL, NULL);
+}
+
 static void fractional_scale_handle_resource_destroy(struct wl_resource *resource) {
 	assert(wl_resource_instance_of(resource, &wp_fractional_scale_v1_interface, &fractional_scale_impl));
 	struct forward_surface *fwd_surface = wl_resource_get_user_data(resource);

--- a/forward.c
+++ b/forward.c
@@ -1302,6 +1302,71 @@ void bind_wl_subcompositor(struct wl_client *client, void *data,
 	wl_resource_set_implementation(resource, &subcompositor_impl, NULL, NULL);
 }
 
+/* Minimal wl_seat. Some terminals (e.g. foot) refuse to start when no seat is
+ * advertised ("no seats available"). Plugins are wallpapers and receive no
+ * input while the session is locked, so this seat advertises no capabilities
+ * and its device accessors return inert objects. This is independent of the
+ * real seat swaylock uses to read the unlock password. */
+static void nested_pointer_set_cursor(struct wl_client *client,
+		struct wl_resource *resource, uint32_t serial,
+		struct wl_resource *surface, int32_t hx, int32_t hy) { }
+static void nested_pointer_release(struct wl_client *client,
+		struct wl_resource *resource) { wl_resource_destroy(resource); }
+static const struct wl_pointer_interface pointer_impl = {
+	.set_cursor = nested_pointer_set_cursor,
+	.release = nested_pointer_release,
+};
+static void nested_keyboard_release(struct wl_client *client,
+		struct wl_resource *resource) { wl_resource_destroy(resource); }
+static const struct wl_keyboard_interface keyboard_impl = {
+	.release = nested_keyboard_release,
+};
+static void nested_touch_release(struct wl_client *client,
+		struct wl_resource *resource) { wl_resource_destroy(resource); }
+static const struct wl_touch_interface touch_impl = {
+	.release = nested_touch_release,
+};
+static void nested_seat_get_pointer(struct wl_client *client,
+		struct wl_resource *resource, uint32_t id) {
+	struct wl_resource *r = wl_resource_create(client, &wl_pointer_interface,
+		wl_resource_get_version(resource), id);
+	if (r) wl_resource_set_implementation(r, &pointer_impl, NULL, NULL);
+}
+static void nested_seat_get_keyboard(struct wl_client *client,
+		struct wl_resource *resource, uint32_t id) {
+	struct wl_resource *r = wl_resource_create(client, &wl_keyboard_interface,
+		wl_resource_get_version(resource), id);
+	if (r) wl_resource_set_implementation(r, &keyboard_impl, NULL, NULL);
+}
+static void nested_seat_get_touch(struct wl_client *client,
+		struct wl_resource *resource, uint32_t id) {
+	struct wl_resource *r = wl_resource_create(client, &wl_touch_interface,
+		wl_resource_get_version(resource), id);
+	if (r) wl_resource_set_implementation(r, &touch_impl, NULL, NULL);
+}
+static void nested_seat_release(struct wl_client *client,
+		struct wl_resource *resource) { wl_resource_destroy(resource); }
+static const struct wl_seat_interface seat_impl = {
+	.get_pointer = nested_seat_get_pointer,
+	.get_keyboard = nested_seat_get_keyboard,
+	.get_touch = nested_seat_get_touch,
+	.release = nested_seat_release,
+};
+void bind_wl_seat(struct wl_client *client, void *data,
+		uint32_t version, uint32_t id) {
+	struct wl_resource *resource =
+		wl_resource_create(client, &wl_seat_interface, version, id);
+	if (resource == NULL) {
+		wl_client_post_no_memory(client);
+		return;
+	}
+	wl_resource_set_implementation(resource, &seat_impl, NULL, NULL);
+	wl_seat_send_capabilities(resource, 0);
+	if (version >= 2) {
+		wl_seat_send_name(resource, "seat0");
+	}
+}
+
 static void fractional_scale_handle_resource_destroy(struct wl_resource *resource) {
 	assert(wl_resource_instance_of(resource, &wp_fractional_scale_v1_interface, &fractional_scale_impl));
 	struct forward_surface *fwd_surface = wl_resource_get_user_data(resource);

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -119,6 +119,7 @@ struct swaylock_bg_server {
 	struct wl_global *wlr_layer_shell;
 	struct wl_global *compositor;
 	struct wl_global *subcompositor;
+	struct wl_global *seat;
 	struct wl_global *shm;
 	struct wl_global *xdg_output_manager;
 	struct wl_global *zwp_linux_dmabuf;
@@ -555,6 +556,7 @@ struct swaylock_surface {
  */
 void bind_wl_compositor(struct wl_client *client, void *data, uint32_t version, uint32_t id);
 void bind_wl_subcompositor(struct wl_client *client, void *data, uint32_t version, uint32_t id);
+void bind_wl_seat(struct wl_client *client, void *data, uint32_t version, uint32_t id);
 void bind_wl_shm(struct wl_client *client, void *data, uint32_t version, uint32_t id);
 void bind_linux_dmabuf(struct wl_client *client, void *data, uint32_t version, uint32_t id);
 void bind_drm(struct wl_client *client, void *data, uint32_t version, uint32_t id);

--- a/include/swaylock.h
+++ b/include/swaylock.h
@@ -118,6 +118,7 @@ struct swaylock_bg_server {
 	struct wl_event_loop *loop;
 	struct wl_global *wlr_layer_shell;
 	struct wl_global *compositor;
+	struct wl_global *subcompositor;
 	struct wl_global *shm;
 	struct wl_global *xdg_output_manager;
 	struct wl_global *zwp_linux_dmabuf;
@@ -553,6 +554,7 @@ struct swaylock_surface {
  * to crash swaylock than to crash the compositor.
  */
 void bind_wl_compositor(struct wl_client *client, void *data, uint32_t version, uint32_t id);
+void bind_wl_subcompositor(struct wl_client *client, void *data, uint32_t version, uint32_t id);
 void bind_wl_shm(struct wl_client *client, void *data, uint32_t version, uint32_t id);
 void bind_linux_dmabuf(struct wl_client *client, void *data, uint32_t version, uint32_t id);
 void bind_drm(struct wl_client *client, void *data, uint32_t version, uint32_t id);

--- a/main.c
+++ b/main.c
@@ -2495,6 +2495,8 @@ int main(int argc, char **argv) {
 		&wl_compositor_interface, 4, &state.forward, bind_wl_compositor);
 	state.server.subcompositor = wl_global_create(state.server.display,
 		&wl_subcompositor_interface, 1, &state.forward, bind_wl_subcompositor);
+	state.server.seat = wl_global_create(state.server.display,
+		&wl_seat_interface, 7, &state.forward, bind_wl_seat);
 	state.server.shm = wl_global_create(state.server.display,
 		&wl_shm_interface, 1, &state.forward, bind_wl_shm);
 	if (state.forward.drm) {

--- a/main.c
+++ b/main.c
@@ -2493,6 +2493,8 @@ int main(int argc, char **argv) {
 	// Also TODO: forwarding linux-dmabuf and (only the device part) of wl-drm
 	state.server.compositor = wl_global_create(state.server.display,
 		&wl_compositor_interface, 4, &state.forward, bind_wl_compositor);
+	state.server.subcompositor = wl_global_create(state.server.display,
+		&wl_subcompositor_interface, 1, &state.forward, bind_wl_subcompositor);
 	state.server.shm = wl_global_create(state.server.display,
 		&wl_shm_interface, 1, &state.forward, bind_wl_shm);
 	if (state.forward.drm) {


### PR DESCRIPTION
### Context

I'm using swaylock-plugin to show a *live terminal* as the per-output lock background (a `--command-each` that wraps a terminal emulator as a wlr-layer-shell surface via `windowtolayer`, so a running text program is visible while the session is locked. swaylock-plugin is the only secure (`ext-session-lock`) locker I've found that can composite live per-output content, so this is a great fit, but the nested compositor it presents to plugins (`forward.c`) only exposes a subset of Wayland globals, and common terminals bail out before drawing because two of them are missing.

### Problem

- **`foot`** aborts at startup with *"no seats available"*, and separately needs `wl_subcompositor`.
- Anything built on **smithay-client-toolkit** (e.g. **alacritty**) aborts with *"missing wl_subcompositor"*.

In both cases the program never renders, so the background silently fails. (A minimal terminal like `havoc`, which binds neither global, already works.)

### Change

Two small commits, each adding a minimal global to the forwarding compositor:

1. **`wl_subcompositor`**: accepts `get_subsurface` and returns an inert `wl_subsurface`. Plugin child surfaces are never assigned a lock-surface role, so their commits are already ignored by `nested_surface_commit()`; this just lets the client start and draw its main surface.
2. **`wl_seat`**: advertises a seat with **no capabilities** (`capabilities 0`, name `seat0`); its pointer/keyboard/touch accessors return inert objects.

Both are wired up in `main.c` alongside the existing `wl_compositor` global.

### Why this is safe for a locker

The advertised seat is **independent of the real seat swaylock uses to read the unlock password**, it reports no capabilities and never delivers input events, so a plugin cannot observe keystrokes, pointer, or touch, and all input continues to go only to the locker. The subcompositor is likewise inert: subsurface state is accepted but not composited. Neither global gives a plugin any new way to interfere with the lock or the unlock path; they only let well-behaved clients get far enough to render their background. Existing plugins that don't bind these globals are unaffected.

### Testing

Built on `v1.8.7`. With this change, `foot` and `alacritty` start and render correctly as the lock background; without it they abort as described above. `havoc` continues to work unchanged.

### Note

This is one of a pair, my other PR (#29 29) handles the `ext-session-lock` exact-size rule that terminals also trip on by rounding to a whole character-cell grid. A terminal background needs both, but the two fixes are independent and can be reviewed/merged separately.